### PR TITLE
General bug fixes and small improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ It can be executed as a command line application or integrated into your own app
 module's API.  The generated SARIF log file is designed to align closer with the SARIF standard than
 the SARIF logs output by the CheckmarxOne CLI.
 
+Review the [release notes](RELEASE_NOTES.md) for version updates.
+
+
 ## Features
 
 * Generates one SARIF `Run` entry per scan engine.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,12 @@
+# Release Notes
+
+## 1.0.3
+
+* A few bug fixes related to interpreting missing JSON fields for some SAST results.
+* All "Not Exploitable" results are now excluded from all engines that support state triage.
+* Added a value for the Sarif standard `level` translated from each engine's Severity concept.
+
+## 1.0.2
+
+* Detailed work to make the Sarif output more compatible with GitHub security result display.
+

--- a/cxone_sarif/run_factory.py
+++ b/cxone_sarif/run_factory.py
@@ -22,10 +22,18 @@ class RunFactory:
 
   @staticmethod
   def get_value_safe(key : str, json : Dict) -> Any:
+    if json is None:
+      return None
+    
     if key in json.keys():
       return json[key]
     else:
       return None
+    
+  @staticmethod
+  def get_value_safe_with_default(key: str, json : Dict, default : Any) -> Any:
+    value = RunFactory.get_value_safe(key, json)
+    return value if value is not None else default
 
   @staticmethod
   def __prep_identifier(s : str) -> str:
@@ -89,3 +97,15 @@ class RunFactory:
       return __nvd_help_base + cve_id
     else:
       return __sca_help_base + cve_id
+    
+  @staticmethod
+  def translate_severity_to_level(severity : str) -> str:
+
+    map = {
+      "critical" : "error",
+      "high" : "error",
+      "medium" : "error",
+      "low" : "warning",
+    }
+
+    return map.get(severity.lower(), "note") if severity is not None else "note"

--- a/cxone_sarif/v210/containers/containers_run.py
+++ b/cxone_sarif/v210/containers/containers_run.py
@@ -96,6 +96,7 @@ class ContainersRun(RunFactory):
           "imageSpec" : image_spec,
           "cve" : cve_id
         },
+        level=RunFactory.translate_severity_to_level(ContainersRun.get_value_safe("severity", result)),
         properties = {
           "severity" : ContainersRun.get_value_safe("severity", result),
           "packageId" : package_id,

--- a/cxone_sarif/v210/iac/iac_run.py
+++ b/cxone_sarif/v210/iac/iac_run.py
@@ -93,6 +93,7 @@ class IaCRun(RunFactory):
           "similarityID" : IaCRun.get_value_safe("similarityID", result),
           "queryKey" : vuln_id
         },
+        level=RunFactory.translate_severity_to_level(IaCRun.get_value_safe("severity", result)),
         properties = {
           "severity" : IaCRun.get_value_safe("severity", result),
           "platform" : query_platform,

--- a/cxone_sarif/v210/iac/iac_run.py
+++ b/cxone_sarif/v210/iac/iac_run.py
@@ -53,6 +53,9 @@ class IaCRun(RunFactory):
     results = []
 
     async for result in page_generator(retrieve_iac_security_scan_results, "results", client=client, scan_id=scan_id):
+      state = IaCRun.get_value_safe("state", result)
+      if state is not None and state == "NOT_EXPLOITABLE":
+        continue
 
       query_name = IaCRun.get_value_safe("queryName", result)
       query_platform = IaCRun.get_value_safe("platform", result)

--- a/cxone_sarif/v210/sast/sast_run.py
+++ b/cxone_sarif/v210/sast/sast_run.py
@@ -190,6 +190,10 @@ class SastRun(RunFactory):
     results = []
 
     async for result in page_generator(SastRun.__fetch_results_with_cached_descriptions, "results", client=client, scan_id=scan_id, limit=200):
+      state = SastRun.get_value_safe("state", result)
+      if state is not None and state == "NOT_EXPLOITABLE":
+        continue
+      
       group = SastRun.get_value_safe("group", result)
       query_name = SastRun.get_value_safe("queryName", result)
       queryId = int(result['queryID'])

--- a/cxone_sarif/v210/sast/sast_run.py
+++ b/cxone_sarif/v210/sast/sast_run.py
@@ -204,8 +204,8 @@ class SastRun(RunFactory):
           name=SastRun.make_pascal_case_identifier(query_name),
           short_description = 
             MultiformatMessageString(text=SastRun.make_title(SastRun.get_value_safe("languageName", result), SastRun.get_value_safe("queryName", result))),
-          full_description = MultiformatMessageString(text=query_desc['risk'] if query_desc is not None else "Not available."),
-          help = MultiformatMessageString(text=query_desc['generalRecommendations'] if query_desc is not None else "Not available."),
+          full_description = MultiformatMessageString(text=RunFactory.get_value_safe_with_default("risk", query_desc, "Not available.")),
+          help = MultiformatMessageString(text=RunFactory.get_value_safe_with_default("generalRecommendations", query_desc, "Not available.")),
           help_uri = SastRun._default_help_uri,
           properties = {
             "queryID" : queryId,
@@ -300,9 +300,10 @@ class SastRun(RunFactory):
           str(Path(f"sast-results/{project_id}/{scan_id}?resultId={urllib.parse.quote_plus(result['pathSystemID'])}"))
 
       results.append(Result(
-        message = SastRun.__make_description(query_desc['resultDescription'] if query_desc is not None else "Not available.", 
+        message = SastRun.__make_description(RunFactory.get_value_safe_with_default("resultDescription", query_desc, "Not available."), 
                     nodes[0], nodes[-1:][0], api_sec_props, viewer_link),
         rule_id = rule_id_key,
+        level=RunFactory.translate_severity_to_level(SastRun.get_value_safe('severity', result)),
         locations=[cur_loop_loc] if cur_loop_loc is not None else None,
         hosted_viewer_uri=viewer_link,
         partial_fingerprints={

--- a/cxone_sarif/v210/sca/sca_run.py
+++ b/cxone_sarif/v210/sca/sca_run.py
@@ -148,6 +148,7 @@ class ScaRun(RunFactory):
                                            ScaRun.get_value_safe("PackageName", vuln),
                                            ScaRun.get_value_safe("PackageVersion", vuln)),
         rule_id = vuln_id,
+        level=RunFactory.translate_severity_to_level(ScaRun.get_value_safe("Severity", vuln)),
         locations = locations,
         hosted_viewer_uri = viewer_url,
         code_flows=code_flows,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "dataclasses-json==0.6.7",
     "docopt==0.6.2",
     "aiofiles==24.1.0",
-    "cxone-api@https://github.com/checkmarx-ts/cxone-async-api/releases/download/1.0.5/cxone_api-1.0.5-py3-none-any.whl"
+    "cxone-api@https://github.com/checkmarx-ts/cxone-async-api/releases/download/1.0.8/cxone_api-1.0.8-py3-none-any.whl"
 ]
 description = "CheckmarxOne Sarif Transformation API"
 requires-python = ">=3.9"


### PR DESCRIPTION
* A few bug fixes related to interpreting missing JSON fields for some SAST results.
* All "Not Exploitable" results are now excluded from all engines that support state triage.
* Added a value for the Sarif standard `level` translated from each engine's Severity concept.