### PR TITLE
Adjusts dependency req and Similarity ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ The module can be installed manually the URL for the install `.whl` file from th
 pip install https://github.com/checkmarx-ts/cxone-sarif/releases/download/X.X.X/cxone_sarif-X.X.X-py3-none-any.whl
 ```
 
+For command-line usage, install with the `[cli]` extra to include the required `docopt` dependency:
+
+```Bash
+pip install https://github.com/checkmarx-ts/cxone-sarif/releases/download/X.X.X/cxone_sarif-X.X.X-py3-none-any.whl[cli]
+```
+
 ## Using the API
 
 The `__main__.py` file is a good example of using the `cxone_sarif` module.  The basics:
@@ -98,6 +104,8 @@ Usage: cxone-sarif [-h | --help | -v | --version] --tenant TENANT (--region REGI
   SARIF Log Generation Options:
   --no-sast           Suppress static code analysis scan results.
   --no-sast-apisec    Do not augment SAST results with API security scan results.
+  --sast-append-similarity-id    Append similarity ID to SAST result messages (max 256 chars total).
+                      This option is disabled by default.
 
   --no-sca            Suppress software composition analysis scan results.
   

--- a/cxone_sarif/__main__.py
+++ b/cxone_sarif/__main__.py
@@ -2,12 +2,11 @@ import asyncio
 import os
 import logging
 import sys
+import argparse
 from typing import Dict
 from asyncio import Semaphore
 from pathlib import Path
 import aiofiles
-from docopt import docopt
-from docopt import DocoptExit
 import cxone_api as cx
 from cxone_sarif.log import bootstrap
 from cxone_sarif import get_sarif_v210_log_for_scan
@@ -18,117 +17,171 @@ from cxone_sarif.__version__ import __version__
 DEFAULT_LOGLEVEL = "INFO"
 
 
+def create_parser():
+    """Create the argument parser for the application."""
+    parser = argparse.ArgumentParser(
+        prog="cxone-sarif",
+        description="Generate SARIF logs from CheckmarxOne scan results",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    
+    # Version and help
+    parser.add_argument("-v", "--version", action="version", 
+                       version=f"cxone-sarif {__version__}")
+    
+    # Required arguments
+    parser.add_argument("--tenant", required=True,
+                       help="The name of the tenant for use with the specified CheckmarxOne service endpoint.")
+    
+    # Multi-tenant vs Single-tenant options
+    parser.add_argument("--region",
+                       help="The multi-tenant region where the tenant is hosted. Use one of: US,US2,EU,EU2,DEU,ANZ,India,Singapore,UAE")
+    
+    parser.add_argument("--url",
+                       help="The URL for the single-tenant CheckmarxOne portal. Must be used with --iam-url.")
+    
+    parser.add_argument("--iam-url", 
+                       help="The URL for the single-tenant CheckmarxOne IAM endpoint. Must be used with --url.")
+    
+    # Authentication options
+    parser.add_argument("--api-key", 
+                       help="The API key to be used for authentication.")
+    parser.add_argument("--use-env-api-key", action="store_true",
+                       help="Retrieve the API key from the environment variable CX_APIKEY.")
+    
+    parser.add_argument("--client", 
+                       help="The name of the OAuth client to be used for authentication. Must be used with --secret.")
+    
+    parser.add_argument("--use-env-oauth", action="store_true",
+                       help="Retrieve the OAuth credentials from the environment variables CX_OCLIENT and CX_OSECRET.")
+    
+    # OAuth secret (required if --client is specified)
+    parser.add_argument("--secret",
+                       help="The OAuth secret associated with the OAuth client. Must be used with --client.")
+    
+    # CheckmarxOne API options
+    parser.add_argument("--timeout", type=int, default=60,
+                       help="The timeout, in seconds, for API operations. (default: 60)")
+    parser.add_argument("--retries", type=int, default=3,
+                       help="The number of API call retries on failure. (default: 3)")
+    parser.add_argument("--delay", type=int, default=15,
+                       help="The maximum seconds to delay between retries for API call failures. (default: 15)")
+    parser.add_argument("-k", action="store_true",
+                       help="Ignore SSL verification failures.")
+    parser.add_argument("--proxy",
+                       help="A value in the form of HOST:PORT that is used as a proxy server.")
+    
+    # SARIF Log Generation Options
+    parser.add_argument("--no-sast", action="store_true",
+                       help="Suppress static code analysis scan results.")
+    parser.add_argument("--no-sast-apisec", action="store_true",
+                       help="Do not augment SAST results with API security scan results.")
+    parser.add_argument("--no-sca", action="store_true",
+                       help="Suppress software composition analysis scan results.")
+    parser.add_argument("--no-kics", action="store_true",
+                       help="Suppress infrastructure as code scan results.")
+    parser.add_argument("--no-containers", action="store_true",
+                       help="Suppress container security scan results.")
+    parser.add_argument("--outdir", default=".",
+                       help="Directory where to write the SARIF log files. (default: .)")
+    parser.add_argument("-t", type=int, default=2,
+                       help="The number of concurrent scan report generations. (default: 2) Keep at 2 when using with multi-tenant Checkmarx One for best stability. The maximum is 8.")
+    
+    # Logging Output Options
+    parser.add_argument("--level", default="INFO",
+                       choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+                       help="Log level (default: INFO)")
+    parser.add_argument("--log-file",
+                       help="A file where logs are written.")
+    parser.add_argument("-q", action="store_true",
+                       help="Do not output logs to the console.")
+    
+    # Scan IDs
+    parser.add_argument("scanids", nargs="+", metavar="SCANIDS",
+                       help="One or more space-separated scan ids that will each generate a file containing a SARIF log.")
+    
+    return parser
+
+
+def validate_args(args):
+    """Validate argument combinations that can't be handled by argparse alone."""
+    # Check that we have either region OR (url + iam-url)
+    if not args.region and not (args.url and args.iam_url):
+        raise ValueError("Either --region OR both --url and --iam-url must be provided.")
+    
+    # Check that we don't have both region and single-tenant options
+    if args.region and (args.url or args.iam_url):
+        raise ValueError("Cannot use --region with single-tenant options (--url, --iam-url).")
+    
+    # If --url is provided, --iam-url must also be provided
+    if args.url and not args.iam_url:
+        raise ValueError("When using single-tenant options, both --url and --iam-url must be provided.")
+    
+    if args.iam_url and not args.url:
+        raise ValueError("When using single-tenant options, both --url and --iam-url must be provided.")
+    
+    # If --client is provided, --secret must also be provided
+    if args.client and not args.secret:
+        raise ValueError("When using --client, --secret must also be provided.")
+    
+    if args.secret and not args.client:
+        raise ValueError("When using --secret, --client must also be provided.")
+    
+    # Check that we have exactly one authentication method
+    auth_methods = [
+        args.api_key is not None,
+        args.use_env_api_key,
+        args.client is not None,
+        args.use_env_oauth
+    ]
+    
+    if sum(auth_methods) != 1:
+        raise ValueError("Exactly one authentication method must be specified: --api-key, --use-env-api-key, --client (with --secret), or --use-env-oauth.")
+
+
 async def main():
-    """Usage: cxone-sarif [-h | --help | -v | --version] --tenant TENANT (--region REGION | (--url URL --iam-url IAMURL))
-                     (--api-key APIKEY | (--client OCLIENT --secret OSECRET) | --use-env-oauth | --use-env-api-key)
-                     [--level LOGLEVEL] [--log-file LOGFILE] [--timeout TIMEOUT] [--delay DELAY] [--retries RETRIES] [--proxy IP:PORT]
-                     [--outdir OUTDIR] [--no-sast] [--no-sast-apisec] [--no-sca] [--no-kics] [--no-containers] [-qk] [-t THREADS] SCANIDS...
-
-    SCANIDS...          One or more space-separated scan ids that will each generate a file containing a SARIF log.
-
-    -h --help           Show this help.
-
-    -v --version        Show version and exit.
-
-    --tenant TENANT     The name of the tenant for use with the specified CheckmarxOne service endpoint.
-
-    Multi-Tenant CheckmarxOne options:
-    --region REGION     The multi-tenant region where the tenant is hosted.
-                        Use one of: {CXREGIONS}
-
-    Single-Tenant CheckmarxOne options:
-    --url URL           The URL for the single-tenant CheckmarxOne portal.
-    --iam-url IAMURL    The URL for the single-tenant CheckmarxOne IAM endpoint.
-
-    Authorization Options:
-
-    --api-key APIKEY    The API key to be used for authentication.
-    --use-env-api-key   Retrieve the API key from the environment variable CX_APIKEY.
-
-    --client OCLIENT    The name of the OAuth client to be used for authentication.
-    --secret OSECRET    The OAuth secret associated with the OAuth client.
-    --use-env-oauth     Retrieve the OAuth credentials from the environment variables CX_OCLIENT and CX_OSECRET.
-
-    -- Additional Options --
-
-    CheckmarxOne API Options
-    --timeout TIMEOUT   The timeout, in seconds, for API operations.  [default: 60]
-
-    --retries RETRIES   The number of API call retries on failure.   [default: 3]
-
-    --delay DELAY       The maximum seconds to delay between retries for API call failures. [default: 15]
-
-    -k                  Ignore SSL verification failures.
-
-    --proxy HOST_PORT   A value in the form of HOST:PORT that is used as a proxy server.
-
-
-    SARIF Log Generation Options:
-    --no-sast           Suppress static code analysis scan results.
-    --no-sast-apisec    Do not augment SAST results with API security scan results.
-
-    --no-sca            Suppress software composition analysis scan results.
-
-    --no-kics           Suppress infrastructure as code scan results.
-
-    --no-containers     Suppress container security scan results.
-
-    --outdir OUTDIR     Directory where to write the SARIF log files.   [default: .]
-
-    -t THREADS          The number of concurrent scan report generations.  [default: 2]
-                        Keep at 2 when using with multi-tenant Checkmarx One for
-                        best stability.  The maximum is 8.
-
-    Logging Output Options:
-    --level LOGLEVEL    Log level [default: INFO]
-                        Use: DEBUG, INFO, WARNING, ERROR, CRITICAL
-
-    --log-file LOGFILE  A file where logs are written.
-
-    -q                  Do not output logs to the console.
-
-    """
-
+    """Main entry point for the application."""
     try:
-        args = docopt(
-            main.__doc__.replace("{CXREGIONS}", ",".join(cx.ApiRegionEndpoints.keys())),
-            version=f"cxone-sarif {__version__}",
-        )
+        parser = create_parser()
+        args = parser.parse_args()
+        
+        # Validate argument combinations
+        validate_args(args)
 
         bootstrap(
-            DEFAULT_LOGLEVEL if args["--level"] is None else args["--level"],
-            not args["-q"],
-            args["--log-file"],
+            DEFAULT_LOGLEVEL if args.level is None else args.level,
+            not args.q,
+            args.log_file,
         )
 
         _log = logging.getLogger("main")
         _log.info(f"{__agent__}/{__version__} start...")
 
-        if not os.path.isdir(args["--outdir"]):
+        if not os.path.isdir(args.outdir):
             _log.error(
-                f"Output directory {args['--outdir']} does not exist, exiting..."
+                f"Output directory {args.outdir} does not exist, exiting..."
             )
             exit(1)
         else:
-            _log.info(f"Report files will be written at: {args['--outdir']}")
+            _log.info(f"Report files will be written at: {args.outdir}")
 
-        if args["--region"] is not None:
-            auth_endpoint = cx.AuthRegionEndpoints[args["--region"]](args["--tenant"])
-            api_endpoint = cx.ApiRegionEndpoints[args["--region"]]()
+        if args.region is not None:
+            auth_endpoint = cx.AuthRegionEndpoints[args.region](args.tenant)
+            api_endpoint = cx.ApiRegionEndpoints[args.region]()
         else:
-            auth_endpoint = cx.CxOneAuthEndpoint(args["--tenant"], args["--iam-url"])
-            api_endpoint = cx.CxOneApiEndpoint(args["--url"])
+            auth_endpoint = cx.CxOneAuthEndpoint(args.tenant, args.iam_url)
+            api_endpoint = cx.CxOneApiEndpoint(args.url)
 
-        if args["--proxy"] is not None:
-            proxy = {"http": args["--proxy"], "https": args["--proxy"]}
+        if args.proxy is not None:
+            proxy = {"http": args.proxy, "https": args.proxy}
         else:
             proxy = None
 
         client = cxone_client_factory(args, auth_endpoint, api_endpoint, proxy)
 
-        concurrency = Semaphore(max(1, min(int(args["-t"]), 8)))
+        concurrency = Semaphore(max(1, min(int(args.t), 8)))
 
-        if len(args["SCANIDS"]) > len(set(args["SCANIDS"])):
+        if len(args.scanids) > len(set(args.scanids)):
             _log.warning(
                 "Some scan ids that were defined multiple times, only one log will be produced per unique scan id."
             )
@@ -139,31 +192,36 @@ async def main():
                     execute_on_scanid(
                         client,
                         scanid,
-                        args["--outdir"],
+                        args.outdir,
                         ReportOpts(
                             SastOpts=SastOpts(
-                                SkipSast=args["--no-sast"],
-                                OmitApiResults=args["--no-sast-apisec"],
+                                SkipSast=args.no_sast,
+                                OmitApiResults=args.no_sast_apisec,
                             ),
-                            SkipSca=args["--no-sca"],
-                            SkipKics=args["--no-kics"],
-                            SkipContainers=args["--no-containers"],
+                            SkipSca=args.no_sca,
+                            SkipKics=args.no_kics,
+                            SkipContainers=args.no_containers,
                         ),
                         concurrency,
                     )
                 )
-                for scanid in set(args["SCANIDS"])
+                for scanid in set(args.scanids)
             ]
         )
 
         exit(max([x.result() for x in task_result]))
-    except DocoptExit as bad_args:
-        print("Incorrect arguments provided.")
-        print(bad_args)
-        exit(1)
+    except (ValueError, SystemExit) as e:
+        if isinstance(e, ValueError):
+            print(f"Argument error: {e}")
+            exit(1)
+        else:
+            # Re-raise SystemExit (this happens when argparse encounters --help, --version, or invalid args)
+            raise
     except Exception as ex:
         print(ex)
         exit(1)
+
+    _log.info(f"{__agent__}/{__version__} complete.")
 
     _log.info(f"{__agent__}/{__version__} complete.")
 
@@ -174,7 +232,7 @@ async def execute_on_scanid(
     outdir: str,
     opts: ReportOpts,
     concurrency: Semaphore,
-) -> None:
+) -> int:
 
     async with concurrency:
         log = logging.getLogger(f"execute_on_scanid:{scan_id}")
@@ -194,15 +252,15 @@ async def execute_on_scanid(
 
 
 def cxone_client_factory(
-    args: Dict,
+    args: argparse.Namespace,
     auth_endpoint: cx.CxOneAuthEndpoint,
     api_endpoint: cx.CxOneApiEndpoint,
     proxy: Dict,
 ) -> cx.CxOneClient:
-    if args["--api-key"] is not None or args["--use-env-api-key"]:
+    if args.api_key is not None or args.use_env_api_key:
 
-        if args["--api-key"] is not None:
-            key = args["--api-key"]
+        if args.api_key is not None:
+            key = args.api_key
         elif "CX_APIKEY" in os.environ.keys():
             key = os.environ["CX_APIKEY"]
         else:
@@ -213,20 +271,18 @@ def cxone_client_factory(
             f"{__agent__}/{__version__}",
             auth_endpoint,
             api_endpoint,
-            timeout=int(args["--timeout"]),
-            retries=int(args["--retries"]),
-            retry_delay_s=int(args["--delay"]),
+            timeout=int(args.timeout),
+            retries=int(args.retries),
+            retry_delay_s=int(args.delay),
             proxy=proxy,
-            ssl_verify=not (args["-k"]),
+            ssl_verify=not (args.k),
         )
 
-    elif (args["--client"] is not None and args["--secret"] is not None) or args[
-        "--use-env-oauth"
-    ]:
+    elif (args.client is not None and args.secret is not None) or args.use_env_oauth:
 
-        if args["--client"] is not None and args["--secret"] is not None:
-            client = args["--client"]
-            secret = args["--secret"]
+        if args.client is not None and args.secret is not None:
+            client = args.client
+            secret = args.secret
         elif "CX_OCLIENT" in os.environ.keys() and "CX_OSECRET" in os.environ.keys():
             client = os.environ["CX_OCLIENT"]
             secret = os.environ["CX_OSECRET"]
@@ -241,11 +297,11 @@ def cxone_client_factory(
             f"{__agent__}/{__version__}",
             auth_endpoint,
             api_endpoint,
-            timeout=int(args["--timeout"]),
-            retries=int(args["--retries"]),
-            retry_delay_s=int(args["--delay"]),
+            timeout=int(args.timeout),
+            retries=int(args.retries),
+            retry_delay_s=int(args.delay),
             proxy=proxy,
-            ssl_verify=not (args["-k"]),
+            ssl_verify=not (args.k),
         )
 
 

--- a/cxone_sarif/__main__.py
+++ b/cxone_sarif/__main__.py
@@ -2,11 +2,12 @@ import asyncio
 import os
 import logging
 import sys
-import argparse
 from typing import Dict
 from asyncio import Semaphore
 from pathlib import Path
 import aiofiles
+from docopt import docopt
+from docopt import DocoptExit
 import cxone_api as cx
 from cxone_sarif.log import bootstrap
 from cxone_sarif import get_sarif_v210_log_for_scan
@@ -17,173 +18,118 @@ from cxone_sarif.__version__ import __version__
 DEFAULT_LOGLEVEL = "INFO"
 
 
-def create_parser():
-    """Create the argument parser for the application."""
-    parser = argparse.ArgumentParser(
-        prog="cxone-sarif",
-        description="Generate SARIF logs from CheckmarxOne scan results",
-        formatter_class=argparse.RawDescriptionHelpFormatter,
-    )
-    
-    # Version and help
-    parser.add_argument("-v", "--version", action="version", 
-                       version=f"cxone-sarif {__version__}")
-    
-    # Required arguments
-    parser.add_argument("--tenant", required=True,
-                       help="The name of the tenant for use with the specified CheckmarxOne service endpoint.")
-    
-    # Multi-tenant vs Single-tenant options
-    parser.add_argument("--region",
-                       help="The multi-tenant region where the tenant is hosted. Use one of: US,US2,EU,EU2,DEU,ANZ,India,Singapore,UAE")
-    
-    parser.add_argument("--url",
-                       help="The URL for the single-tenant CheckmarxOne portal. Must be used with --iam-url.")
-    
-    parser.add_argument("--iam-url", 
-                       help="The URL for the single-tenant CheckmarxOne IAM endpoint. Must be used with --url.")
-    
-    # Authentication options
-    parser.add_argument("--api-key", 
-                       help="The API key to be used for authentication.")
-    parser.add_argument("--use-env-api-key", action="store_true",
-                       help="Retrieve the API key from the environment variable CX_APIKEY.")
-    
-    parser.add_argument("--client", 
-                       help="The name of the OAuth client to be used for authentication. Must be used with --secret.")
-    
-    parser.add_argument("--use-env-oauth", action="store_true",
-                       help="Retrieve the OAuth credentials from the environment variables CX_OCLIENT and CX_OSECRET.")
-    
-    # OAuth secret (required if --client is specified)
-    parser.add_argument("--secret",
-                       help="The OAuth secret associated with the OAuth client. Must be used with --client.")
-    
-    # CheckmarxOne API options
-    parser.add_argument("--timeout", type=int, default=60,
-                       help="The timeout, in seconds, for API operations. (default: 60)")
-    parser.add_argument("--retries", type=int, default=3,
-                       help="The number of API call retries on failure. (default: 3)")
-    parser.add_argument("--delay", type=int, default=15,
-                       help="The maximum seconds to delay between retries for API call failures. (default: 15)")
-    parser.add_argument("-k", action="store_true",
-                       help="Ignore SSL verification failures.")
-    parser.add_argument("--proxy",
-                       help="A value in the form of HOST:PORT that is used as a proxy server.")
-    
-    # SARIF Log Generation Options
-    parser.add_argument("--no-sast", action="store_true",
-                       help="Suppress static code analysis scan results.")
-    parser.add_argument("--no-sast-apisec", action="store_true",
-                       help="Do not augment SAST results with API security scan results.")
-    parser.add_argument("--sast-append-similarity-id", action="store_true",
-                       help="Append similarity ID to SAST result messages (max 256 chars total).")
-    parser.add_argument("--no-sca", action="store_true",
-                       help="Suppress software composition analysis scan results.")
-    parser.add_argument("--no-kics", action="store_true",
-                       help="Suppress infrastructure as code scan results.")
-    parser.add_argument("--no-containers", action="store_true",
-                       help="Suppress container security scan results.")
-    parser.add_argument("--outdir", default=".",
-                       help="Directory where to write the SARIF log files. (default: .)")
-    parser.add_argument("-t", type=int, default=2,
-                       help="The number of concurrent scan report generations. (default: 2) Keep at 2 when using with multi-tenant Checkmarx One for best stability. The maximum is 8.")
-    
-    # Logging Output Options
-    parser.add_argument("--level", default="INFO",
-                       choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
-                       help="Log level (default: INFO)")
-    parser.add_argument("--log-file",
-                       help="A file where logs are written.")
-    parser.add_argument("-q", action="store_true",
-                       help="Do not output logs to the console.")
-    
-    # Scan IDs
-    parser.add_argument("scanids", nargs="+", metavar="SCANIDS",
-                       help="One or more space-separated scan ids that will each generate a file containing a SARIF log.")
-    
-    return parser
-
-
-def validate_args(args):
-    """Validate argument combinations that can't be handled by argparse alone."""
-    # Check that we have either region OR (url + iam-url)
-    if not args.region and not (args.url and args.iam_url):
-        raise ValueError("Either --region OR both --url and --iam-url must be provided.")
-    
-    # Check that we don't have both region and single-tenant options
-    if args.region and (args.url or args.iam_url):
-        raise ValueError("Cannot use --region with single-tenant options (--url, --iam-url).")
-    
-    # If --url is provided, --iam-url must also be provided
-    if args.url and not args.iam_url:
-        raise ValueError("When using single-tenant options, both --url and --iam-url must be provided.")
-    
-    if args.iam_url and not args.url:
-        raise ValueError("When using single-tenant options, both --url and --iam-url must be provided.")
-    
-    # If --client is provided, --secret must also be provided
-    if args.client and not args.secret:
-        raise ValueError("When using --client, --secret must also be provided.")
-    
-    if args.secret and not args.client:
-        raise ValueError("When using --secret, --client must also be provided.")
-    
-    # Check that we have exactly one authentication method
-    auth_methods = [
-        args.api_key is not None,
-        args.use_env_api_key,
-        args.client is not None,
-        args.use_env_oauth
-    ]
-    
-    if sum(auth_methods) != 1:
-        raise ValueError("Exactly one authentication method must be specified: --api-key, --use-env-api-key, --client (with --secret), or --use-env-oauth.")
-
-
 async def main():
-    """Main entry point for the application."""
+    """Usage: cxone-sarif [-h | --help | -v | --version] --tenant TENANT (--region REGION | (--url URL --iam-url IAMURL))
+                     (--api-key APIKEY | (--client OCLIENT --secret OSECRET) | --use-env-oauth | --use-env-api-key)
+                     [--level LOGLEVEL] [--log-file LOGFILE] [--timeout TIMEOUT] [--delay DELAY] [--retries RETRIES] [--proxy IP:PORT]
+                     [--outdir OUTDIR] [--no-sast] [--no-sast-apisec] [--no-sca] [--no-kics] [--no-containers] [-qk] [-t THREADS] SCANIDS...
+
+    SCANIDS...          One or more space-separated scan ids that will each generate a file containing a SARIF log.
+
+    -h --help           Show this help.
+
+    -v --version        Show version and exit.
+
+    --tenant TENANT     The name of the tenant for use with the specified CheckmarxOne service endpoint.
+
+    Multi-Tenant CheckmarxOne options:
+    --region REGION     The multi-tenant region where the tenant is hosted.
+                        Use one of: {CXREGIONS}
+
+    Single-Tenant CheckmarxOne options:
+    --url URL           The URL for the single-tenant CheckmarxOne portal.
+    --iam-url IAMURL    The URL for the single-tenant CheckmarxOne IAM endpoint.
+
+    Authorization Options:
+
+    --api-key APIKEY    The API key to be used for authentication.
+    --use-env-api-key   Retrieve the API key from the environment variable CX_APIKEY.
+
+    --client OCLIENT    The name of the OAuth client to be used for authentication.
+    --secret OSECRET    The OAuth secret associated with the OAuth client.
+    --use-env-oauth     Retrieve the OAuth credentials from the environment variables CX_OCLIENT and CX_OSECRET.
+
+    -- Additional Options --
+
+    CheckmarxOne API Options
+    --timeout TIMEOUT   The timeout, in seconds, for API operations.  [default: 60]
+
+    --retries RETRIES   The number of API call retries on failure.   [default: 3]
+
+    --delay DELAY       The maximum seconds to delay between retries for API call failures. [default: 15]
+
+    -k                  Ignore SSL verification failures.
+
+    --proxy HOST_PORT   A value in the form of HOST:PORT that is used as a proxy server.
+
+
+    SARIF Log Generation Options:
+    --no-sast           Suppress static code analysis scan results.
+    --no-sast-apisec    Do not augment SAST results with API security scan results.
+    --sast-append-similarity-id    Append similarity ID to SAST result messages (max 256 chars total).
+
+    --no-sca            Suppress software composition analysis scan results.
+
+    --no-kics           Suppress infrastructure as code scan results.
+
+    --no-containers     Suppress container security scan results.
+
+    --outdir OUTDIR     Directory where to write the SARIF log files.   [default: .]
+
+    -t THREADS          The number of concurrent scan report generations.  [default: 2]
+                        Keep at 2 when using with multi-tenant Checkmarx One for
+                        best stability.  The maximum is 8.
+
+    Logging Output Options:
+    --level LOGLEVEL    Log level [default: INFO]
+                        Use: DEBUG, INFO, WARNING, ERROR, CRITICAL
+
+    --log-file LOGFILE  A file where logs are written.
+
+    -q                  Do not output logs to the console.
+
+    """
+
     try:
-        parser = create_parser()
-        args = parser.parse_args()
-        
-        # Validate argument combinations
-        validate_args(args)
+        args = docopt(
+            main.__doc__.replace("{CXREGIONS}", ",".join(cx.ApiRegionEndpoints.keys())),
+            version=f"cxone-sarif {__version__}",
+        )
 
         bootstrap(
-            DEFAULT_LOGLEVEL if args.level is None else args.level,
-            not args.q,
-            args.log_file,
+            DEFAULT_LOGLEVEL if args["--level"] is None else args["--level"],
+            not args["-q"],
+            args["--log-file"],
         )
 
         _log = logging.getLogger("main")
         _log.info(f"{__agent__}/{__version__} start...")
 
-        if not os.path.isdir(args.outdir):
+        if not os.path.isdir(args["--outdir"]):
             _log.error(
-                f"Output directory {args.outdir} does not exist, exiting..."
+                f"Output directory {args['--outdir']} does not exist, exiting..."
             )
             exit(1)
         else:
-            _log.info(f"Report files will be written at: {args.outdir}")
+            _log.info(f"Report files will be written at: {args['--outdir']}")
 
-        if args.region is not None:
-            auth_endpoint = cx.AuthRegionEndpoints[args.region](args.tenant)
-            api_endpoint = cx.ApiRegionEndpoints[args.region]()
+        if args["--region"] is not None:
+            auth_endpoint = cx.AuthRegionEndpoints[args["--region"]](args["--tenant"])
+            api_endpoint = cx.ApiRegionEndpoints[args["--region"]]()
         else:
-            auth_endpoint = cx.CxOneAuthEndpoint(args.tenant, args.iam_url)
-            api_endpoint = cx.CxOneApiEndpoint(args.url)
+            auth_endpoint = cx.CxOneAuthEndpoint(args["--tenant"], args["--iam-url"])
+            api_endpoint = cx.CxOneApiEndpoint(args["--url"])
 
-        if args.proxy is not None:
-            proxy = {"http": args.proxy, "https": args.proxy}
+        if args["--proxy"] is not None:
+            proxy = {"http": args["--proxy"], "https": args["--proxy"]}
         else:
             proxy = None
 
         client = cxone_client_factory(args, auth_endpoint, api_endpoint, proxy)
 
-        concurrency = Semaphore(max(1, min(int(args.t), 8)))
+        concurrency = Semaphore(max(1, min(int(args["-t"]), 8)))
 
-        if len(args.scanids) > len(set(args.scanids)):
+        if len(args["SCANIDS"]) > len(set(args["SCANIDS"])):
             _log.warning(
                 "Some scan ids that were defined multiple times, only one log will be produced per unique scan id."
             )
@@ -194,37 +140,32 @@ async def main():
                     execute_on_scanid(
                         client,
                         scanid,
-                        args.outdir,
+                        args["--outdir"],
                         ReportOpts(
                             SastOpts=SastOpts(
-                                SkipSast=args.no_sast,
-                                OmitApiResults=args.no_sast_apisec,
-                                AppendSimilarityId=args.sast_append_similarity_id,
+                                SkipSast=args["--no-sast"],
+                                OmitApiResults=args["--no-sast-apisec"],
+                                AppendSimilarityId=args["--sast-append-similarity-id"],
                             ),
-                            SkipSca=args.no_sca,
-                            SkipKics=args.no_kics,
-                            SkipContainers=args.no_containers,
+                            SkipSca=args["--no-sca"],
+                            SkipKics=args["--no-kics"],
+                            SkipContainers=args["--no-containers"],
                         ),
                         concurrency,
                     )
                 )
-                for scanid in set(args.scanids)
+                for scanid in set(args["SCANIDS"])
             ]
         )
 
         exit(max([x.result() for x in task_result]))
-    except (ValueError, SystemExit) as e:
-        if isinstance(e, ValueError):
-            print(f"Argument error: {e}")
-            exit(1)
-        else:
-            # Re-raise SystemExit (this happens when argparse encounters --help, --version, or invalid args)
-            raise
+    except DocoptExit as bad_args:
+        print("Incorrect arguments provided.")
+        print(bad_args)
+        exit(1)
     except Exception as ex:
         print(ex)
         exit(1)
-
-    _log.info(f"{__agent__}/{__version__} complete.")
 
     _log.info(f"{__agent__}/{__version__} complete.")
 
@@ -235,7 +176,7 @@ async def execute_on_scanid(
     outdir: str,
     opts: ReportOpts,
     concurrency: Semaphore,
-) -> int:
+) -> None:
 
     async with concurrency:
         log = logging.getLogger(f"execute_on_scanid:{scan_id}")
@@ -255,15 +196,15 @@ async def execute_on_scanid(
 
 
 def cxone_client_factory(
-    args: argparse.Namespace,
+    args: Dict,
     auth_endpoint: cx.CxOneAuthEndpoint,
     api_endpoint: cx.CxOneApiEndpoint,
     proxy: Dict,
 ) -> cx.CxOneClient:
-    if args.api_key is not None or args.use_env_api_key:
+    if args["--api-key"] is not None or args["--use-env-api-key"]:
 
-        if args.api_key is not None:
-            key = args.api_key
+        if args["--api-key"] is not None:
+            key = args["--api-key"]
         elif "CX_APIKEY" in os.environ.keys():
             key = os.environ["CX_APIKEY"]
         else:
@@ -274,18 +215,20 @@ def cxone_client_factory(
             f"{__agent__}/{__version__}",
             auth_endpoint,
             api_endpoint,
-            timeout=int(args.timeout),
-            retries=int(args.retries),
-            retry_delay_s=int(args.delay),
+            timeout=int(args["--timeout"]),
+            retries=int(args["--retries"]),
+            retry_delay_s=int(args["--delay"]),
             proxy=proxy,
-            ssl_verify=not (args.k),
+            ssl_verify=not (args["-k"]),
         )
 
-    elif (args.client is not None and args.secret is not None) or args.use_env_oauth:
+    elif (args["--client"] is not None and args["--secret"] is not None) or args[
+        "--use-env-oauth"
+    ]:
 
-        if args.client is not None and args.secret is not None:
-            client = args.client
-            secret = args.secret
+        if args["--client"] is not None and args["--secret"] is not None:
+            client = args["--client"]
+            secret = args["--secret"]
         elif "CX_OCLIENT" in os.environ.keys() and "CX_OSECRET" in os.environ.keys():
             client = os.environ["CX_OCLIENT"]
             secret = os.environ["CX_OSECRET"]
@@ -300,11 +243,11 @@ def cxone_client_factory(
             f"{__agent__}/{__version__}",
             auth_endpoint,
             api_endpoint,
-            timeout=int(args.timeout),
-            retries=int(args.retries),
-            retry_delay_s=int(args.delay),
+            timeout=int(args["--timeout"]),
+            retries=int(args["--retries"]),
+            retry_delay_s=int(args["--delay"]),
             proxy=proxy,
-            ssl_verify=not (args.k),
+            ssl_verify=not (args["-k"]),
         )
 
 

--- a/cxone_sarif/__main__.py
+++ b/cxone_sarif/__main__.py
@@ -76,6 +76,8 @@ def create_parser():
                        help="Suppress static code analysis scan results.")
     parser.add_argument("--no-sast-apisec", action="store_true",
                        help="Do not augment SAST results with API security scan results.")
+    parser.add_argument("--sast-append-similarity-id", action="store_true",
+                       help="Append similarity ID to SAST result messages (max 256 chars total).")
     parser.add_argument("--no-sca", action="store_true",
                        help="Suppress software composition analysis scan results.")
     parser.add_argument("--no-kics", action="store_true",
@@ -197,6 +199,7 @@ async def main():
                             SastOpts=SastOpts(
                                 SkipSast=args.no_sast,
                                 OmitApiResults=args.no_sast_apisec,
+                                AppendSimilarityId=args.sast_append_similarity_id,
                             ),
                             SkipSca=args.no_sca,
                             SkipKics=args.no_kics,

--- a/cxone_sarif/opts/__init__.py
+++ b/cxone_sarif/opts/__init__.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 class SastOpts:
     SkipSast: bool
     OmitApiResults: bool
+    AppendSimilarityId: bool
 
 
 @dataclass(frozen=True)
@@ -16,7 +17,7 @@ class ReportOpts:
 
 
 DEFAULT = ReportOpts(
-    SastOpts=SastOpts(SkipSast=False, OmitApiResults=False),
+    SastOpts=SastOpts(SkipSast=False, OmitApiResults=False, AppendSimilarityId=False),
     SkipSca=False,
     SkipKics=False,
     SkipContainers=False,

--- a/cxone_sarif/v210/sast/__init__.py
+++ b/cxone_sarif/v210/sast/__init__.py
@@ -7,4 +7,4 @@ from .sast_run import SastRun
 
 async def get_sast_run(client : CxOneClient, opts : SastOpts, project_id : str, scan_id : str, platform : str, versions : CxOneVersions, 
                        organization : str, info_uri : str) -> Run:
-  return await SastRun.factory(client, opts.OmitApiResults, project_id, scan_id, platform, versions.SAST, organization, info_uri)
+  return await SastRun.factory(client, opts.OmitApiResults, opts.AppendSimilarityId, project_id, scan_id, platform, versions.SAST, organization, info_uri)

--- a/cxone_sarif/v210/sast/sast_run.py
+++ b/cxone_sarif/v210/sast/sast_run.py
@@ -143,7 +143,7 @@ class SastRun(RunFactory):
       
     # Handle similarity ID appending
     if append_similarity_id and similarity_id is not None:
-      similarity_suffix = f" ID:{similarity_id}"
+      similarity_suffix = f" SIMID:{similarity_id}"
       max_length = 256
       
       # For text field

--- a/cxone_sarif/v210/sast/sast_run.py
+++ b/cxone_sarif/v210/sast/sast_run.py
@@ -143,7 +143,7 @@ class SastRun(RunFactory):
       
     # Handle similarity ID appending
     if append_similarity_id and similarity_id is not None:
-      similarity_suffix = f" {similarity_id}"
+      similarity_suffix = f" ID:{similarity_id}"
       max_length = 256
       
       # For text field

--- a/cxone_sarif/v210/sast/sast_run.py
+++ b/cxone_sarif/v210/sast/sast_run.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Any
+from typing import Dict, List, Any, Optional
 from cxone_api import CxOneClient
 from cxone_api.util import json_on_ok, page_generator
 from sarif_om import (Run, 
@@ -99,7 +99,7 @@ class SastRun(RunFactory):
     return response
   
   @staticmethod
-  def __make_description(description : str, source_node : Dict, sink_node : Dict, apisec_results : List[ApiSecResult], viewer_link : str) -> Message:
+  def __make_description(description : str, source_node : Dict, sink_node : Dict, apisec_results : List[ApiSecResult], viewer_link : str, similarity_id : Optional[str] = None, append_similarity_id : bool = False) -> Message:
     text = markdown = description
 
     def get_or_unknown(node, key):
@@ -141,6 +141,26 @@ class SastRun(RunFactory):
           text += f"{ares.http_method} {ares.endpoint_path}\n"
           markdown += f"* {ares.http_method} {ares.endpoint_path}\n"
       
+    # Handle similarity ID appending
+    if append_similarity_id and similarity_id is not None:
+      similarity_suffix = f" {similarity_id}"
+      max_length = 256
+      
+      # For text field
+      if len(text + similarity_suffix) > max_length:
+        # Truncate text to make room for similarity ID
+        available_length = max_length - len(similarity_suffix)
+        text = text[:available_length] + similarity_suffix
+      else:
+        text += similarity_suffix
+      
+      # For markdown field  
+      if len(markdown + similarity_suffix) > max_length:
+        # Truncate markdown to make room for similarity ID
+        available_length = max_length - len(similarity_suffix)
+        markdown = markdown[:available_length] + similarity_suffix
+      else:
+        markdown += similarity_suffix
 
     return Message(text=text, markdown=markdown)
 
@@ -178,7 +198,7 @@ class SastRun(RunFactory):
     return index
   
   @staticmethod
-  async def factory(client : CxOneClient, omit_apisec : bool, project_id : str, scan_id : str, 
+  async def factory(client : CxOneClient, omit_apisec : bool, append_similarity_id : bool, project_id : str, scan_id : str, 
                     platform : str, version : str, organization : str, info_uri : str) -> Run:
 
 
@@ -305,7 +325,8 @@ class SastRun(RunFactory):
 
       results.append(Result(
         message = SastRun.__make_description(RunFactory.get_value_safe_with_default("resultDescription", query_desc, "Not available."), 
-                    nodes[0], nodes[-1:][0], api_sec_props, viewer_link),
+                    nodes[0], nodes[-1:][0], api_sec_props, viewer_link, 
+                    str(result['similarityID']), append_similarity_id),
         rule_id = rule_id_key,
         level=RunFactory.translate_severity_to_level(SastRun.get_value_safe('severity', result)),
         locations=[cur_loop_loc] if cur_loop_loc is not None else None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,10 +10,12 @@ dependencies = [
     "jsonpath-ng==1.7.0",
     "jschema-to-python==1.2.3",
     "dataclasses-json==0.6.7",
-    "docopt==0.6.2",
     "aiofiles==24.1.0",
     "cxone-api@https://github.com/checkmarx-ts/cxone-async-api/releases/download/1.0.9/cxone_api-1.0.9-py3-none-any.whl"
 ]
+
+[project.optional-dependencies]
+cli = ["docopt==0.6.2"]
 description = "CheckmarxOne Sarif Transformation API"
 requires-python = ">=3.9"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ dependencies = [
     "jsonpath-ng==1.7.0",
     "jschema-to-python==1.2.3",
     "dataclasses-json==0.6.7",
-    "docopt==0.6.2",
     "aiofiles==24.1.0",
     "cxone-api@https://github.com/checkmarx-ts/cxone-async-api/releases/download/1.0.9/cxone_api-1.0.9-py3-none-any.whl"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,8 +14,6 @@ dependencies = [
     "cxone-api@https://github.com/checkmarx-ts/cxone-async-api/releases/download/1.0.9/cxone_api-1.0.9-py3-none-any.whl"
 ]
 
-[project.optional-dependencies]
-cli = ["docopt==0.6.2"]
 description = "CheckmarxOne Sarif Transformation API"
 requires-python = ">=3.9"
 
@@ -27,3 +25,6 @@ package-dir = {"cxone_sarif" = "cxone_sarif"}
 
 [tool.setuptools.dynamic]
 version = { attr = "cxone_sarif.__version__.__version__" }
+
+[project.optional-dependencies]
+cli = ["docopt==0.6.2"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "jsonpath-ng==1.7.0",
     "jschema-to-python==1.2.3",
     "dataclasses-json==0.6.7",
+    "docopt==0.6.2",
     "aiofiles==24.1.0",
     "cxone-api@https://github.com/checkmarx-ts/cxone-async-api/releases/download/1.0.9/cxone_api-1.0.9-py3-none-any.whl"
 ]


### PR DESCRIPTION
DocOpt does not work on all platforms, for similar platforms like lambdas that require manylinux its unable to be used.

This also adds the similarity ID to be injected into the SAST findings to be able to be used in GHAS finding results.