### PR TITLE
Adds reporting to properties if its a dev ot test dependency

### DIFF
--- a/cxone_sarif/v210/sca/sca_run.py
+++ b/cxone_sarif/v210/sca/sca_run.py
@@ -2,7 +2,7 @@ from cxone_sarif.utils import normalize_file_uri
 from cxone_sarif.run_factory import RunFactory
 from cxone_api import CxOneClient
 from cxone_api.util import json_on_ok
-from cxone_api.high.sca import get_sca_report, ScaReportOptions, ScaReportType
+from cxone_api.high.sca import get_sca_report, ScaReportOptions, ScaReportType, ScaTenantPackages
 from typing import Dict, List, Tuple
 from pathlib import Path
 import urllib
@@ -47,7 +47,7 @@ class ScaRun(RunFactory):
 
 
   @staticmethod
-  def __get_vulnerabilities(client : CxOneClient, vulnerabilities : List[Dict], location_index : Dict[str, List[str]], project_id : str, scan_id : str) -> Tuple[List[Result], Dict[str, str]]:
+  def __get_vulnerabilities(client : CxOneClient, vulnerabilities : List[Dict], location_index : Dict[str, List[str]], dep_type_index : Dict[str, Dict], project_id : str, scan_id : str) -> Tuple[List[Result], Dict[str, str]]:
 
     results = []
     rules = {}
@@ -167,6 +167,8 @@ class ScaRun(RunFactory):
           "firstFoundAt" : ScaRun.get_value_safe("FirstFoundAt", vuln),
           "riskType" : "package",
           "isViolatingPolicy" : str(ScaRun.get_value_safe("IsViolatingPolicy", vuln)),
+          "isDevDependency" : str(dep_type_index.get(package_id, {}).get("isDevDependency", False)),
+          "isTestDependency" : str(dep_type_index.get(package_id, {}).get("isTest", False)),
         }
       ))
 
@@ -183,7 +185,25 @@ class ScaRun(RunFactory):
     for package in packages:
       package_loc_index[ScaRun.get_value_safe("Id", package)] = ScaRun.get_value_safe("Locations", package)
 
-    results, rules = ScaRun.__get_vulnerabilities(client, ScaRun.get_value_safe("Vulnerabilities", scan_report), package_loc_index, project_id, scan_id)
+    # isDevDependency and isTest are not present in the ScanReportJson package data;
+    # they are retrieved via the SCA GraphQL API using ScaTenantPackages, filtered by scanId and projectId.
+    package_dep_type_index = {}
+    tenant_pkgs = ScaTenantPackages(client)
+    tenant_pkgs.where = {
+      "and": [
+        {"scanId": {"eq": scan_id}},
+        {"projectId": {"eq": project_id}}
+      ]
+    }
+    async for pkg in tenant_pkgs:
+      pkg_id = pkg.get("packageId")
+      if pkg_id:
+        package_dep_type_index[pkg_id] = {
+          "isDevDependency": bool(pkg.get("isDevDependency")),
+          "isTest": bool(pkg.get("isTest")),
+        }
+
+    results, rules = ScaRun.__get_vulnerabilities(client, ScaRun.get_value_safe("Vulnerabilities", scan_report), package_loc_index, package_dep_type_index, project_id, scan_id)
 
     driver = ToolComponent(name="CheckmarxOne-SCA", guid=ScaRun.get_tool_guid(),
                            product_suite=platform,

--- a/cxone_sarif/v210/sca/sca_run.py
+++ b/cxone_sarif/v210/sca/sca_run.py
@@ -47,7 +47,7 @@ class ScaRun(RunFactory):
 
 
   @staticmethod
-  def __get_vulnerabilities(client : CxOneClient, vulnerabilities : List[Dict], location_index : Dict[str, List[str]], project_id : str, scan_id : str) -> Tuple[List[Result], Dict[str, str]]:
+  def __get_vulnerabilities(client : CxOneClient, vulnerabilities : List[Dict], location_index : Dict[str, List[str]], dep_type_index : Dict[str, Dict], project_id : str, scan_id : str) -> Tuple[List[Result], Dict[str, str]]:
 
     results = []
     rules = {}
@@ -167,6 +167,8 @@ class ScaRun(RunFactory):
           "firstFoundAt" : ScaRun.get_value_safe("FirstFoundAt", vuln),
           "riskType" : "package",
           "isViolatingPolicy" : str(ScaRun.get_value_safe("IsViolatingPolicy", vuln)),
+          "isDevDependency" : str(dep_type_index.get(package_id, {}).get("isDevDependency", False)),
+          "isTestDependency" : str(dep_type_index.get(package_id, {}).get("isTest", False)),
         }
       ))
 
@@ -179,11 +181,17 @@ class ScaRun(RunFactory):
 
     packages = ScaRun.get_value_safe("Packages", scan_report)
     package_loc_index = {}
+    package_dep_type_index = {}
 
     for package in packages:
-      package_loc_index[ScaRun.get_value_safe("Id", package)] = ScaRun.get_value_safe("Locations", package)
+      pkg_id = ScaRun.get_value_safe("Id", package)
+      package_loc_index[pkg_id] = ScaRun.get_value_safe("Locations", package)
+      package_dep_type_index[pkg_id] = {
+        "isDevDependency" : ScaRun.get_value_safe("IsDevDependency", package),
+        "isTest" : ScaRun.get_value_safe("IsTest", package),
+      }
 
-    results, rules = ScaRun.__get_vulnerabilities(client, ScaRun.get_value_safe("Vulnerabilities", scan_report), package_loc_index, project_id, scan_id)
+    results, rules = ScaRun.__get_vulnerabilities(client, ScaRun.get_value_safe("Vulnerabilities", scan_report), package_loc_index, package_dep_type_index, project_id, scan_id)
 
     driver = ToolComponent(name="CheckmarxOne-SCA", guid=ScaRun.get_tool_guid(),
                            product_suite=platform,

--- a/cxone_sarif/v210/sca/sca_run.py
+++ b/cxone_sarif/v210/sca/sca_run.py
@@ -2,7 +2,8 @@ from cxone_sarif.utils import normalize_file_uri
 from cxone_sarif.run_factory import RunFactory
 from cxone_api import CxOneClient
 from cxone_api.util import json_on_ok
-from cxone_api.high.sca import get_sca_report, ScaReportOptions, ScaReportType, ScaTenantPackages
+from cxone_api.high.sca import get_sca_report, ScaReportOptions, ScaReportType
+from cxone_api.high.sca.analysis.tenant_packages import ScaTenantPackages
 from typing import Dict, List, Tuple
 from pathlib import Path
 import urllib

--- a/cxone_sarif/v210/sca/sca_run.py
+++ b/cxone_sarif/v210/sca/sca_run.py
@@ -2,11 +2,10 @@ from cxone_sarif.utils import normalize_file_uri
 from cxone_sarif.run_factory import RunFactory
 from cxone_api import CxOneClient
 from cxone_api.util import json_on_ok
-from cxone_api.high.sca import get_sca_report, ScaReportOptions, ScaReportType
+from cxone_api.high.sca import get_sca_report, ScaReportOptions, ScaReportType, ScaTenantPackages
 from typing import Dict, List, Tuple
 from pathlib import Path
 import urllib
-import requests
 from sarif_om import (Run,
                       Tool,
                       RunAutomationDetails,
@@ -187,48 +186,22 @@ class ScaRun(RunFactory):
       package_loc_index[ScaRun.get_value_safe("Id", package)] = ScaRun.get_value_safe("Locations", package)
 
     # isDevDependency and isTest are not present in the ScanReportJson package data;
-    # they must be retrieved via the SCA GraphQL API filtered by scanId.
+    # they are retrieved via the SCA GraphQL API using ScaTenantPackages, filtered by scanId and projectId.
     package_dep_type_index = {}
-    gql_query = """
-      query($where: ReportingPackageModelFilterInput, $take: Int!, $skip: Int!) {
-        reportingPackages(where: $where, take: $take, skip: $skip) {
-          packageId
-          isDevDependency
-          isTest
+    tenant_pkgs = ScaTenantPackages(client)
+    tenant_pkgs.where = {
+      "and": [
+        {"scanId": {"eq": scan_id}},
+        {"projectId": {"eq": project_id}}
+      ]
+    }
+    async for pkg in tenant_pkgs:
+      pkg_id = pkg.get("packageId")
+      if pkg_id:
+        package_dep_type_index[pkg_id] = {
+          "isDevDependency": bool(pkg.get("isDevDependency")),
+          "isTest": bool(pkg.get("isTest")),
         }
-      }
-    """
-    gql_url = client.api_endpoint.rstrip("/") + "/sca/graphql/graphql"
-    skip = 0
-    page_size = 500
-    while True:
-      gql_response = json_on_ok(await client.exec_request(
-        requests.post, gql_url,
-        json={
-          "query": gql_query,
-          "variables": {
-            "where": {
-              "and": [
-                {"scanId": {"eq": scan_id}},
-                {"projectId": {"eq": project_id}}
-              ]
-            },
-            "take": page_size,
-            "skip": skip
-          }
-        }
-      ))
-      pkg_page = (gql_response.get("data") or {}).get("reportingPackages", [])
-      for pkg in pkg_page:
-        pkg_id = pkg.get("packageId")
-        if pkg_id:
-          package_dep_type_index[pkg_id] = {
-            "isDevDependency": bool(pkg.get("isDevDependency")),
-            "isTest": bool(pkg.get("isTest")),
-          }
-      if len(pkg_page) < page_size:
-        break
-      skip += page_size
 
     results, rules = ScaRun.__get_vulnerabilities(client, ScaRun.get_value_safe("Vulnerabilities", scan_report), package_loc_index, package_dep_type_index, project_id, scan_id)
 

--- a/cxone_sarif/v210/sca/sca_run.py
+++ b/cxone_sarif/v210/sca/sca_run.py
@@ -167,8 +167,8 @@ class ScaRun(RunFactory):
           "firstFoundAt" : ScaRun.get_value_safe("FirstFoundAt", vuln),
           "riskType" : "package",
           "isViolatingPolicy" : str(ScaRun.get_value_safe("IsViolatingPolicy", vuln)),
-          "isDevDependency" : str(dep_type_index.get(package_id, {}).get("isDevDependency", False)),
-          "isTestDependency" : str(dep_type_index.get(package_id, {}).get("isTest", False)),
+          "isDevDependency" : bool(dep_type_index.get(package_id, {}).get("isDevDependency", False)),
+          "isTestDependency" : bool(dep_type_index.get(package_id, {}).get("isTest", False)),
         }
       ))
 

--- a/cxone_sarif/v210/sca/sca_run.py
+++ b/cxone_sarif/v210/sca/sca_run.py
@@ -2,10 +2,11 @@ from cxone_sarif.utils import normalize_file_uri
 from cxone_sarif.run_factory import RunFactory
 from cxone_api import CxOneClient
 from cxone_api.util import json_on_ok
-from cxone_api.high.sca import get_sca_report, ScaReportOptions, ScaReportType, ScaTenantPackages
+from cxone_api.high.sca import get_sca_report, ScaReportOptions, ScaReportType
 from typing import Dict, List, Tuple
 from pathlib import Path
 import urllib
+import requests
 from sarif_om import (Run,
                       Tool,
                       RunAutomationDetails,
@@ -186,17 +187,43 @@ class ScaRun(RunFactory):
       package_loc_index[ScaRun.get_value_safe("Id", package)] = ScaRun.get_value_safe("Locations", package)
 
     # isDevDependency and isTest are not present in the ScanReportJson package data;
-    # they must be retrieved via the ScaTenantPackages GQL API filtered by scanId.
+    # they must be retrieved via the SCA GraphQL API filtered by scanId.
     package_dep_type_index = {}
-    tenant_pkgs = ScaTenantPackages(client)
-    tenant_pkgs.where = {"scanId" : {"eq" : scan_id}}
-    async for pkg in tenant_pkgs:
-      pkg_id = pkg.get("packageId")
-      if pkg_id:
-        package_dep_type_index[pkg_id] = {
-          "isDevDependency" : pkg.get("isDevDependency", False),
-          "isTest" : pkg.get("isTest", False),
+    gql_query = """
+      query($where: ReportingPackageModelFilterInput, $take: Int!, $skip: Int!) {
+        reportingPackages(where: $where, take: $take, skip: $skip) {
+          packageId
+          isDevDependency
+          isTest
         }
+      }
+    """
+    gql_url = client.api_endpoint.rstrip("/") + "/sca/graphql/graphql"
+    skip = 0
+    page_size = 500
+    while True:
+      gql_response = json_on_ok(await client.exec_request(
+        requests.post, gql_url,
+        json={
+          "query": gql_query,
+          "variables": {
+            "where": {"scanId": {"eq": scan_id}},
+            "take": page_size,
+            "skip": skip
+          }
+        }
+      ))
+      pkg_page = (gql_response.get("data") or {}).get("reportingPackages", [])
+      for pkg in pkg_page:
+        pkg_id = pkg.get("packageId")
+        if pkg_id:
+          package_dep_type_index[pkg_id] = {
+            "isDevDependency": pkg.get("isDevDependency", False),
+            "isTest": pkg.get("isTest", False),
+          }
+      if len(pkg_page) < page_size:
+        break
+      skip += page_size
 
     results, rules = ScaRun.__get_vulnerabilities(client, ScaRun.get_value_safe("Vulnerabilities", scan_report), package_loc_index, package_dep_type_index, project_id, scan_id)
 

--- a/cxone_sarif/v210/sca/sca_run.py
+++ b/cxone_sarif/v210/sca/sca_run.py
@@ -207,7 +207,12 @@ class ScaRun(RunFactory):
         json={
           "query": gql_query,
           "variables": {
-            "where": {"scanId": {"eq": scan_id}},
+            "where": {
+              "and": [
+                {"scanId": {"eq": scan_id}},
+                {"projectId": {"eq": project_id}}
+              ]
+            },
             "take": page_size,
             "skip": skip
           }
@@ -218,8 +223,8 @@ class ScaRun(RunFactory):
         pkg_id = pkg.get("packageId")
         if pkg_id:
           package_dep_type_index[pkg_id] = {
-            "isDevDependency": pkg.get("isDevDependency", False),
-            "isTest": pkg.get("isTest", False),
+            "isDevDependency": bool(pkg.get("isDevDependency")),
+            "isTest": bool(pkg.get("isTest")),
           }
       if len(pkg_page) < page_size:
         break

--- a/cxone_sarif/v210/sca/sca_run.py
+++ b/cxone_sarif/v210/sca/sca_run.py
@@ -2,8 +2,7 @@ from cxone_sarif.utils import normalize_file_uri
 from cxone_sarif.run_factory import RunFactory
 from cxone_api import CxOneClient
 from cxone_api.util import json_on_ok
-from cxone_api.high.sca import get_sca_report, ScaReportOptions, ScaReportType
-from cxone_api.high.sca.analysis.tenant_packages import ScaTenantPackages
+from cxone_api.high.sca import get_sca_report, ScaReportOptions, ScaReportType, ScaTenantPackages
 from typing import Dict, List, Tuple
 from pathlib import Path
 import urllib

--- a/cxone_sarif/v210/sca/sca_run.py
+++ b/cxone_sarif/v210/sca/sca_run.py
@@ -2,7 +2,7 @@ from cxone_sarif.utils import normalize_file_uri
 from cxone_sarif.run_factory import RunFactory
 from cxone_api import CxOneClient
 from cxone_api.util import json_on_ok
-from cxone_api.high.sca import get_sca_report, ScaReportOptions, ScaReportType
+from cxone_api.high.sca import get_sca_report, ScaReportOptions, ScaReportType, ScaTenantPackages
 from typing import Dict, List, Tuple
 from pathlib import Path
 import urllib
@@ -181,15 +181,22 @@ class ScaRun(RunFactory):
 
     packages = ScaRun.get_value_safe("Packages", scan_report)
     package_loc_index = {}
-    package_dep_type_index = {}
 
     for package in packages:
-      pkg_id = ScaRun.get_value_safe("Id", package)
-      package_loc_index[pkg_id] = ScaRun.get_value_safe("Locations", package)
-      package_dep_type_index[pkg_id] = {
-        "isDevDependency" : ScaRun.get_value_safe("IsDevDependency", package),
-        "isTest" : ScaRun.get_value_safe("IsTest", package),
-      }
+      package_loc_index[ScaRun.get_value_safe("Id", package)] = ScaRun.get_value_safe("Locations", package)
+
+    # isDevDependency and isTest are not present in the ScanReportJson package data;
+    # they must be retrieved via the ScaTenantPackages GQL API filtered by scanId.
+    package_dep_type_index = {}
+    tenant_pkgs = ScaTenantPackages(client)
+    tenant_pkgs.where = {"scanId" : {"eq" : scan_id}}
+    async for pkg in tenant_pkgs:
+      pkg_id = pkg.get("packageId")
+      if pkg_id:
+        package_dep_type_index[pkg_id] = {
+          "isDevDependency" : pkg.get("isDevDependency", False),
+          "isTest" : pkg.get("isTest", False),
+        }
 
     results, rules = ScaRun.__get_vulnerabilities(client, ScaRun.get_value_safe("Vulnerabilities", scan_report), package_loc_index, package_dep_type_index, project_id, scan_id)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "jschema-to-python==1.2.3",
     "dataclasses-json==0.6.7",
     "aiofiles==24.1.0",
-    "cxone-api@https://github.com/checkmarx-ts/cxone-async-api/releases/download/1.1.2/cxone_api-1.1.2-py3-none-any.whl"
+    "cxone-api@https://github.com/checkmarx-ts/cxone-async-api/releases/download/1.1.3/cxone_api-1.1.3-py3-none-any.whl"
 ]
 
 description = "CheckmarxOne Sarif Transformation API"


### PR DESCRIPTION
This pull request enhances the SCA (Software Composition Analysis) processing logic to improve dependency type detection and reporting. The main improvement is the integration of additional dependency metadata (`isDevDependency` and `isTest`) by querying the SCA GraphQL API, which enables more accurate vulnerability reporting. The changes also update the `cxone-api` dependency to the latest version.

**Dependency metadata enrichment:**

* Integrated `ScaTenantPackages` from the SCA GraphQL API to retrieve `isDevDependency` and `isTest` flags for each package, using filters for `scanId` and `projectId`, and constructed a `package_dep_type_index` for use in vulnerability processing (`cxone_sarif/v210/sca/sca_run.py`).
* Updated the `__get_vulnerabilities` method to accept and utilize the new `dep_type_index` parameter, and included the `isDevDependency` and `isTestDependency` fields in the result output (`cxone_sarif/v210/sca/sca_run.py`). [[1]](diffhunk://#diff-17c8a2291ab389b630db8be78e009e53362d60846d97cf89818ad326feb423f5L50-R50) [[2]](diffhunk://#diff-17c8a2291ab389b630db8be78e009e53362d60846d97cf89818ad326feb423f5R170-R171)

**Dependency update:**

* Bumped the `cxone-api` package version from `1.1.2` to `1.1.3` in `pyproject.toml` to support the new features and API calls required for dependency metadata enrichment (`pyproject.toml`).

**Imports and type changes:**

* Imported `ScaTenantPackages` from `cxone_api.high.sca` to enable GraphQL API access for dependency metadata (`cxone_sarif/v210/sca/sca_run.py`).