### PR TITLE
Stability fixes and adding additional package properties to SCA outputs

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,7 @@
 
 * Add flags for dependency classification in SCA output.
 * Fix interpretation of an error condition when SAST scan metadata is not available.
+* Bump dependency versions.
 
 ## 1.1.2
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,14 @@
 # Release Notes
 
+## 1.1.3
+
+* Add flags for dependency classification in SCA output.
+* Fix interpretation of an error condition when SAST scan metadata is not available.
+
+## 1.1.2
+
+* Update to cxone-async-api 1.1.2
+
 ## 1.1.1
 
 * Added an option to include the SAST result similarity id in the text description.

--- a/cxone_sarif/v210/sast/sast_run.py
+++ b/cxone_sarif/v210/sast/sast_run.py
@@ -80,15 +80,17 @@ class SastRun(RunFactory):
   @staticmethod
   async def __notifications_factory(metrics : Dict) -> List[ReportingDescriptor]:
     descriptors = []
-    found = SastRun.__metrics_scannedFiles.find(metrics)
 
-    if len(found) > 0 and found[0].value is not None:
-      reported = found[0].value
-      for lang in reported.keys():
-        if 'partiallyGoodFiles' in reported[lang].keys() and int(reported[lang]['partiallyGoodFiles']) > 0:
-          descriptors.append(await SastRun.__partial_file_descriptor_factory(lang, int(reported[lang]['partiallyGoodFiles'])))
-        if 'badFiles' in reported[lang].keys() and int(reported[lang]['badFiles']) > 0:
-          descriptors.append(await SastRun.__bad_file_descriptor_factory(lang, int(reported[lang]['badFiles'])))
+    if metrics is not None:
+      found = SastRun.__metrics_scannedFiles.find(metrics)
+
+      if len(found) > 0 and found[0].value is not None:
+        reported = found[0].value
+        for lang in reported.keys():
+          if 'partiallyGoodFiles' in reported[lang].keys() and int(reported[lang]['partiallyGoodFiles']) > 0:
+            descriptors.append(await SastRun.__partial_file_descriptor_factory(lang, int(reported[lang]['partiallyGoodFiles'])))
+          if 'badFiles' in reported[lang].keys() and int(reported[lang]['badFiles']) > 0:
+            descriptors.append(await SastRun.__bad_file_descriptor_factory(lang, int(reported[lang]['badFiles'])))
     
     return descriptors
   
@@ -184,13 +186,32 @@ class SastRun(RunFactory):
     return index
   
   @staticmethod
+  async def __get_available_metrics(client : CxOneClient, scan_id : str):
+    metric_resp = await retrieve_scan_metrics(client, scan_id)
+
+    if not metric_resp.ok:
+      return None
+
+    return metric_resp.json()
+
+  @staticmethod
+  async def __get_available_metadata(client : CxOneClient, scan_id : str):
+    metadata_resp = await retrieve_scan_metadata(client, scan_id)
+
+    if not metadata_resp.ok:
+      return None
+
+    return metadata_resp.json()
+    
+  
+  @staticmethod
   async def factory(client : CxOneClient, omit_apisec : bool, append_similarity_id : bool, project_id : str, scan_id : str, 
                     platform : str, version : str, organization : str, info_uri : str) -> Run:
 
 
     apisec_index = await SastRun.__make_apisec_index(client, scan_id) if not omit_apisec else {}
 
-    metrics = json_on_ok(await retrieve_scan_metrics(client, scan_id))
+    metrics = await SastRun.__get_available_metrics(client, scan_id)
 
     rules = {}
     results = []
@@ -338,13 +359,13 @@ class SastRun(RunFactory):
                            notifications = await SastRun.__notifications_factory(metrics),
                            rules = [r for r in rules.values()],
                            properties={
-                             "scanMetrics" : metrics
+                             "scanMetrics" : metrics if metrics is not None else {}
                            })
 
-    metadata = json_on_ok(await retrieve_scan_metadata(client, scan_id))
+    metadata = await SastRun.__get_available_metadata(client, scan_id)
     tool = Tool(driver=driver,
                 properties={
-                  "scanMetadata" : metadata
+                  "scanMetadata" : metadata if metadata is not None else {}
                   })
     
     return Run(tool=tool, 

--- a/cxone_sarif/v210/sca/sca_run.py
+++ b/cxone_sarif/v210/sca/sca_run.py
@@ -47,7 +47,7 @@ class ScaRun(RunFactory):
 
 
   @staticmethod
-  def __get_vulnerabilities(client : CxOneClient, vulnerabilities : List[Dict], location_index : Dict[str, List[str]], project_id : str, scan_id : str) -> Tuple[List[Result], Dict[str, str]]:
+  def __get_vulnerabilities(client : CxOneClient, vulnerabilities : List[Dict], package_index : Dict[str, List[str]], project_id : str, scan_id : str) -> Tuple[List[Result], Dict[str, str]]:
 
     results = []
     rules = {}
@@ -115,7 +115,7 @@ class ScaRun(RunFactory):
       
       locations = None
       
-      if package_id in location_index.keys():
+      if package_id in package_index.keys():
         
         if locations is None:
           locations = []
@@ -125,7 +125,7 @@ class ScaRun(RunFactory):
         # spec says only use more than one location if every location needs to
         # be changed to fix the issue.  GH displays only the first one,
         # but all will be put here for other Sarif consumers.
-        for artifact_loc in location_index[package_id]:
+        for artifact_loc in package_index[package_id].get("Locations", []):
           locations.append (
             Location(
               id=index,
@@ -167,6 +167,23 @@ class ScaRun(RunFactory):
           "firstFoundAt" : ScaRun.get_value_safe("FirstFoundAt", vuln),
           "riskType" : "package",
           "isViolatingPolicy" : str(ScaRun.get_value_safe("IsViolatingPolicy", vuln)),
+          # Package properties
+          "numberOfVersionsSinceLastUpdate" : str(package_index[package_id].get("NumberOfVersionsSinceLastUpdate", 0)),
+          "newestVersionReleaseDate" : package_index[package_id].get("NewestVersionReleaseDate", ""),
+          "newestVersion" : package_index[package_id].get("NewestVersion", ""),
+          "releaseDate" : package_index[package_id].get("ReleaseDate", ""),
+          "nextVersionWithoutVulnerabilities" : package_index[package_id].get("NextVersionWithoutVulnerabilities", ""),
+          "latestVersionWithoutVulnerabilities" : package_index[package_id].get("LatestVersionWithoutVulnerabilities", ""),
+          "nextRecommendedMoreSecureVersion" : package_index[package_id].get("NextRecommendedMoreSecureVersion", ""),
+          "latestRecommendedMoreSecureVersion" : package_index[package_id].get("LatestRecommendedMoreSecureVersion", ""),
+          "isOutdated" : str(package_index[package_id].get("Outdated", False)),
+          "isMalicious" : str(package_index[package_id].get("IsMalicious", False)),
+          "isDirectDependency" : str(package_index[package_id].get("IsDirectDependency", False)),
+          "isDevelopmentDependency" : str(package_index[package_id].get("IsDevelopmentDependency", False)),
+          "isTestDependency" : str(package_index[package_id].get("IsTestDependency", False)),
+          "isNpmVerified" : str(package_index[package_id].get("IsNpmVerified", False)),
+          "isPrivatePackage" : str(package_index[package_id].get("IsPrivatePackage", False)),
+          "supplier" : package_index[package_id].get("Supplier", ""),
         }
       ))
 
@@ -177,13 +194,13 @@ class ScaRun(RunFactory):
     scan_report = json_on_ok(await get_sca_report(client, scan_id, ScaReportOptions(fileFormat=ScaReportType.ScanReportJson)))
     scan_report_summary = ScaRun.get_value_safe("RiskReportSummary", scan_report)
 
-    packages = ScaRun.get_value_safe("Packages", scan_report)
-    package_loc_index = {}
+    packages = scan_report.get("Packages", {})
+    package_def_index = {}
 
     for package in packages:
-      package_loc_index[ScaRun.get_value_safe("Id", package)] = ScaRun.get_value_safe("Locations", package)
+      package_def_index[ScaRun.get_value_safe("Id", package)] = package
 
-    results, rules = ScaRun.__get_vulnerabilities(client, ScaRun.get_value_safe("Vulnerabilities", scan_report), package_loc_index, project_id, scan_id)
+    results, rules = ScaRun.__get_vulnerabilities(client, ScaRun.get_value_safe("Vulnerabilities", scan_report), package_def_index, project_id, scan_id)
 
     driver = ToolComponent(name="CheckmarxOne-SCA", guid=ScaRun.get_tool_guid(),
                            product_suite=platform,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "jschema-to-python==1.2.3",
     "dataclasses-json==0.6.7",
     "aiofiles==24.1.0",
-    "cxone-api@https://github.com/checkmarx-ts/cxone-async-api/releases/download/1.1.2/cxone_api-1.1.2-py3-none-any.whl"
+    "cxone-api@https://github.com/checkmarx-ts/cxone-async-api/releases/download/1.1.3/cxone_api-1.1.3-py3-none-any.whl"
 ]
 
 description = "CheckmarxOne Sarif Transformation API"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "jsonpath-ng==1.7.0",
     "jschema-to-python==1.2.3",
     "dataclasses-json==0.6.7",
-    "aiofiles==24.1.0",
+    "aiofiles==25.1.0",
     "cxone-api@https://github.com/checkmarx-ts/cxone-async-api/releases/download/1.1.3/cxone_api-1.1.3-py3-none-any.whl"
 ]
 


### PR DESCRIPTION
* Stability fixes for SAST metadata and metrics cases where the data is not available.
* Added package properties to vulnerability properties in Sarif output
